### PR TITLE
更新時に通知ノート（更新ページ一覧を含む）を自動発行するように

### DIFF
--- a/.github/workflows/notify-update-by-bot.yml
+++ b/.github/workflows/notify-update-by-bot.yml
@@ -11,11 +11,17 @@ jobs:
     if: ${{ vars.SERVER_URL }}
     env:
       SERVER_URL: ${{ vars.SERVER_URL }}
+      PAGES_URL: ${{ vars.PAGES_URL }}
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+      OLDER: ${{ github.event.before }}
+      NEWER: ${{ github.event.after }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Fetch Before-push commit
+        run: |
+          git fetch origin $OLDER
       - name: Setup Node.js
         uses: actions/setup-node@v4.1.0
         with:

--- a/.github/workflows/notify-update-by-bot.yml
+++ b/.github/workflows/notify-update-by-bot.yml
@@ -1,0 +1,29 @@
+name: Notify Update By Bot
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ vars.SERVER_URL }}
+    env:
+      SERVER_URL: ${{ vars.SERVER_URL }}
+      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.1.0
+        with:
+          node-version: 20.x
+      - name: Setup
+        run: |
+          corepack enable
+          pnpm i --frozen-lockfile
+      - name: Run scripts/notify-update-by-bot.mjs
+        run: |
+          node scripts/notify-update-by-bot.mjs

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
     "sharp": "^0.32.5",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3"
+  },
+  "devDependencies": {
+    "misskey-js": "2024.11.1-alpha.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,10 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
+    devDependencies:
+      misskey-js:
+        specifier: 2024.11.1-alpha.0
+        version: 2024.11.1-alpha.0
 
 packages:
 
@@ -663,6 +667,9 @@ packages:
 
   '@shikijs/vscode-textmate@9.3.0':
     resolution: {integrity: sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==}
+
+  '@simplewebauthn/types@11.0.0':
+    resolution: {integrity: sha512-b2o0wC5u2rWts31dTgBkAtSNKGX0cvL6h8QedNsKmj8O4QoLFQFR3DBVBUlpyVEhYKA+mXGUaXbcOc4JdQ3HzA==}
 
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
@@ -1708,6 +1715,9 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  misskey-js@2024.11.1-alpha.0:
+    resolution: {integrity: sha512-cXZAIlw8h8TNoZsdaOAtD6SXV0irhThSK/OQ7JKGiYBfjz0AO5VFyKF6tCfPrMyBU4kH74GfLP0wTx2d1j/t2g==}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -1972,6 +1982,9 @@ packages:
 
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
+  reconnecting-websocket@4.4.0:
+    resolution: {integrity: sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng==}
 
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
@@ -3227,6 +3240,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@9.3.0': {}
+
+  '@simplewebauthn/types@11.0.0': {}
 
   '@types/acorn@4.0.6':
     dependencies:
@@ -4744,6 +4759,12 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  misskey-js@2024.11.1-alpha.0:
+    dependencies:
+      '@simplewebauthn/types': 11.0.0
+      eventemitter3: 5.0.1
+      reconnecting-websocket: 4.4.0
+
   mkdirp-classic@0.5.3: {}
 
   mrmime@2.0.0: {}
@@ -5027,6 +5048,8 @@ snapshots:
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
+
+  reconnecting-websocket@4.4.0: {}
 
   regenerator-runtime@0.14.1: {}
 

--- a/scripts/notify-update-by-bot.mjs
+++ b/scripts/notify-update-by-bot.mjs
@@ -1,0 +1,14 @@
+import { env } from 'node:process';
+import { api } from 'misskey-js';
+
+const client = new api.APIClient({
+  origin: env.SERVER_URL.replace(/\/$/, ''),
+  credential: env.BOT_TOKEN,
+});
+
+const text = `
+Voskey Docsが更新されました！
+https://voskeydocs.icalo.net/
+`.trim();
+
+await client.request('notes/create', { text });

--- a/scripts/notify-update-by-bot.mjs
+++ b/scripts/notify-update-by-bot.mjs
@@ -1,5 +1,91 @@
-import { env } from 'node:process';
+import { exec } from 'node:child_process';
+import { env as _env, exit } from 'node:process';
 import { api } from 'misskey-js';
+
+const docsDir = 'src/content/docs';
+
+const envValidators = {
+  OLDER: (v) => notEmpty(v),
+  NEWER: (v) => notEmpty(v),
+  BOT_TOKEN: (v) => notEmpty(v),
+  SERVER_URL: (v) => isURL(v),
+  PAGES_URL: (v) => isURL(v),
+};
+
+
+function notEmpty(str) {
+  return (typeof str === 'string')
+    && (str.trim() !== '');
+}
+function isURL(str) {
+  try {
+    new URL(str);
+  } catch(e) {
+    if (e.name === 'TypeError') return false;
+    throw e;
+  }
+  return true;
+}
+
+const env = {};
+for (const envname of Object.keys(envValidators)) {
+  const value = _env[envname];
+  if (envValidators[envname](value)) {
+    env[envname] = value;
+  } else {
+    throw new Error(`Envs validation failed: ${envname} is ${value}`);
+  }
+}
+
+const diffs = await new Promise(
+  resolve => exec(
+    `git diff --name-status ${env.OLDER} ${env.NEWER} -- ${docsDir}`,
+    (error, stdout, stderr) => {
+      // このコマンドが正常終了すればstderrの出力があることはないはず…
+      if (error || stderr) throw error || stderr;
+      resolve(
+        stdout.split('\n').filter(
+          diffline => diffline !== ''
+        )
+      );
+    },
+  ),
+);
+
+if (diffs.length === 0) {
+  console.log('no diffs detected.');
+  exit();
+}
+
+const diffDescriptions = diffs.map(
+  diffline => {
+    const stateDescriptions = {
+      M: '更新',
+      A: '新規',
+      D: '削除',
+    };
+    const regexp = new RegExp([
+      // M, A, Dのいずれか一文字
+      `^([${
+        Object.keys(stateDescriptions).join('')
+      }])`,
+      // 空白
+      '\\s*',
+      // ファイルパス（相対）
+      // 正規表現にファイルパスをねじ込むとパス次第でエスケープがややこしいので後でsliceかreplaceで処理
+      '(\\S.*)\\.\\w+$',
+    ].join(''));
+
+    const matchResult = diffline.match(regexp);
+    if (matchResult == null) throw new Error('Unexpected output of git diff: ' + diffs);
+    const [_whole, state, path] = matchResult;
+    if (!path.startsWith(docsDir)) throw new Error('Unexpected output of git diff: ' + diffs);
+    const pageURL = env.PAGES_URL.replace(/\/$/, '')
+      + path.slice(docsDir.length);
+
+    return `${stateDescriptions[state]}: ${pageURL}`;
+  },
+);
 
 const client = new api.APIClient({
   origin: env.SERVER_URL.replace(/\/$/, ''),
@@ -8,7 +94,8 @@ const client = new api.APIClient({
 
 const text = `
 Voskey Docsが更新されました！
-https://voskeydocs.icalo.net/
+
+${diffDescriptions.join('\n')}
 `.trim();
 
 await client.request('notes/create', { text });


### PR DESCRIPTION
自動更新通知Lv.2です。#2 の通知ノートに更新ページ一覧を含めるようにしました。
[サンプル画像](https://github.com/user-attachments/assets/d2777bef-a874-4eb9-8333-e80929af4d25)
「更新」の字は適宜「新規」「削除」に置き換わります。

## 使い方
#2 に加えて、Variablesから`PAGES_URL`をドキュメントのサイトのルートURLに設定する必要があります。

## 留意点
- [src/content/docs](https://github.com/voskey-dev/voskey-docs/tree/main/src/content/docs)内の変更のみに反応します。
- ファイル名変更時の挙動が未確認です。
- workflow_dispatchが置き物になっています。