### PR TITLE
更新通知botのノート内容を改善

### DIFF
--- a/scripts/notify-update-by-bot.mjs
+++ b/scripts/notify-update-by-bot.mjs
@@ -1,5 +1,6 @@
 import { exec } from 'node:child_process';
 import { env as _env, exit } from 'node:process';
+import { readFile } from 'node:fs/promises';
 import { api } from 'misskey-js';
 
 const docsDir = 'src/content/docs';
@@ -58,8 +59,8 @@ if (diffs.length === 0) {
   exit();
 }
 
-const diffDescriptions = diffs.map(
-  diffline => {
+const diffDescriptions = await Promise.all(diffs.map(
+  async (diffline) => {
     const stateDescriptions = {
       M: '更新',
       A: '新規',
@@ -67,26 +68,30 @@ const diffDescriptions = diffs.map(
     };
     const regexp = new RegExp([
       // M, A, Dのいずれか一文字
-      `^([${
+      `^(?<state>[${
         Object.keys(stateDescriptions).join('')
       }])`,
       // 空白
       '\\s*',
       // ファイルパス（相対）
       // 正規表現にファイルパスをねじ込むとパス次第でエスケープがややこしいので後でsliceかreplaceで処理
-      '(\\S.*)\\.\\w+$',
+      '(?<path>\\S.*)(?<ext>\\.\\w+)$',
     ].join(''));
 
     const matchResult = diffline.match(regexp);
     if (matchResult == null) throw new Error('Unexpected output of git diff: ' + diffs);
-    const [_whole, state, path] = matchResult;
+    const { state, path, ext }  = matchResult.groups;
     if (!path.startsWith(docsDir)) throw new Error('Unexpected output of git diff: ' + diffs);
     const pageURL = env.PAGES_URL.replace(/\/$/, '')
       + path.slice(docsDir.length);
 
-    return `${stateDescriptions[state]}: ${pageURL}`;
+    const fileText = await readFile(path + ext, { encoding: 'utf8' });
+    const title = fileText.match(/^title:\s*(.+)$/m)?.[1]
+      ?? '<ページタイトルの読み取りに失敗>';
+
+    return `${stateDescriptions[state]}: ?[${title}](${pageURL})`;
   },
-);
+));
 
 const client = new api.APIClient({
   origin: env.SERVER_URL.replace(/\/$/, ''),

--- a/scripts/notify-update-by-bot.mjs
+++ b/scripts/notify-update-by-bot.mjs
@@ -10,6 +10,7 @@ const envValidators = {
   BOT_TOKEN: (v) => notEmpty(v),
   SERVER_URL: (v) => isURL(v),
   PAGES_URL: (v) => isURL(v),
+  GITHUB_REPOSITORY: (v) => notEmpty(v),
 };
 
 
@@ -94,6 +95,7 @@ const client = new api.APIClient({
 
 const text = `
 Voskey Docsが更新されました！
+[詳しい変更内容はこちら](https://github.com/${env.GITHUB_REPOSITORY}/compare/${env.OLDER}...${env.NEWER})
 
 ${diffDescriptions.join('\n')}
 `.trim();


### PR DESCRIPTION
ノートに変更前後のdiffを表示するgithubのリンクを追加します。
また、各ページのリンクをページのタイトルで表示されるようにします。

例：
```
Voskey Docsが更新されました！
[詳しい変更内容はこちら](https://github.com/voskey-dev/voskey-docs/compare/f2fd6375fae3c4760f859d1a16b46fa65492aa78...55b742063b890aeea4e6f2a07b68a6f069e46442)

更新: [絵文字申請のライセンス分類](https://voskeydocs.icalo.net/emoji/02-license)
```