### PR TITLE
更新通知手動発行機能

### DIFF
--- a/.github/workflows/notify-update-by-bot.yml
+++ b/.github/workflows/notify-update-by-bot.yml
@@ -4,6 +4,15 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      older_commit:
+        description: '古い方のコミットハッシュ（またはブランチ名）'
+        required: true
+        default: HEAD~1
+      newer_commit:
+        description: '新しい方のコミットハッシュ（またはブランチ名）'
+        required: true
+        default: HEAD
 
 jobs:
   deploy:
@@ -13,15 +22,14 @@ jobs:
       SERVER_URL: ${{ vars.SERVER_URL }}
       PAGES_URL: ${{ vars.PAGES_URL }}
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
-      OLDER: ${{ github.event.before }}
-      NEWER: ${{ github.event.after }}
+      OLDER: ${{ inputs.older_commit || github.event.before }}
+      NEWER: ${{ inputs.newer_commit || github.event.after }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Fetch Before-push commit
-        run: |
-          git fetch origin $OLDER
+        with:
+          fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v4.2.0
         with:


### PR DESCRIPTION
更新通知がエラーなどで正常に発行できなかった時に、手動で発行できるようにします。
多分write-accessを持ってる人しか使えません。

## 使い方
1. リポジトリ画面上部の"Actions"を押します。
2. 画面左の"Notify Update By Bot"を押します。
3. "This workflow has a workflow_dispatch event trigger. Run workflow"という表示が出るはずなので"Run workflow"を押します。
4. 「古い/新しい方のコミットハッシュ」は、直前の変更の更新通知を行う場合は変えなくても問題ありません。それ以外の場合は質問してください。
5. 緑の"Run workflow"を押して待ちます